### PR TITLE
Fix: Incorrect EOD

### DIFF
--- a/internal/billablesbuddy/hours_remaining.go
+++ b/internal/billablesbuddy/hours_remaining.go
@@ -23,33 +23,49 @@ func getTotalExpectedHoursByEndOfDayFromSchedule(date time.Time, s Schedule) flo
 
 func getRemainingHours(date time.Time, h Hour) float64 {
 	eodRemainingHours := getTotalExpectedHoursByEndOfDayFromSchedule(date, h.ExpectedSchedule)
-
 	return eodRemainingHours - h.Actual
 }
 
-func getEstimatedEndOfDay(ts time.Time, remainingHours float64) time.Time {
+func getTotalExpectedHoursByEndOfDay(date time.Time, billables Hour, nonbillables Hour) float64 {
+	eodRemainingHoursBillables := getTotalExpectedHoursByEndOfDayFromSchedule(date, billables.ExpectedSchedule)
+	eodRemainingHoursNonbillables := getTotalExpectedHoursByEndOfDayFromSchedule(date, nonbillables.ExpectedSchedule)
+	return eodRemainingHoursBillables + eodRemainingHoursNonbillables
+}
+
+func getEstimatedEndOfDay(ts time.Time, billables Hour, nonbillables Hour) time.Time {
+	date := getDateFromTime(ts)
+	remainingHoursBillable := getRemainingHours(date, billables)
+	remainingHoursNonbillable := getRemainingHours(date, nonbillables)
+
+	// Cap our remaining nonbillable hours and don't allow to go negative. If nonbillables
+	// go negative, it means the users schedule could possibly be shortend based on a lot of
+	// actual nonbillable - even if billables are low
+	if remainingHoursNonbillable < 0 {
+		remainingHoursNonbillable = 0
+	}
+
+	remainingHoursAll := remainingHoursBillable + remainingHoursNonbillable
+	actualHoursAll := billables.Actual + nonbillables.Actual
+	eodExpectedHours := getTotalExpectedHoursByEndOfDay(date, billables, nonbillables)
+
 	switch {
-	case remainingHours < 0:
+	case remainingHoursAll < 0, actualHoursAll > eodExpectedHours:
 		// EOD is in the past
 		return time.Time{}
-	case remainingHours >= workdayWorkingDurationInHours:
+	case remainingHoursAll >= workdayWorkingDurationInHours:
 		// Remaining hours are longer than a single workday
 		return ts.Add(workdayWorkingDurationInHours * time.Hour)
 	default:
-		remainingMinutes := remainingHours * 60
+		remainingMinutes := remainingHoursAll * 60
 		return ts.Add(time.Duration(remainingMinutes) * time.Minute)
 	}
 }
 
 func getHoursRemaining(ts time.Time, startTime time.Time, billables Hour, nonbillables Hour) HoursRemaining {
-	date := getDateFromTime(ts)
-	remainingHoursBillable := getRemainingHours(date, billables)
-	remainingHoursNonbillable := getRemainingHours(date, nonbillables)
-	remainingHoursAll := remainingHoursBillable + remainingHoursNonbillable
 	hoursRemaining := HoursRemaining{}
-
+	// Only get the estimated EOD if the user has started work today
 	if !startTime.IsZero() {
-		hoursRemaining.EstimatedEOD = getEstimatedEndOfDay(ts, remainingHoursAll)
+		hoursRemaining.EstimatedEOD = getEstimatedEndOfDay(ts, billables, nonbillables)
 	}
 
 	return hoursRemaining


### PR DESCRIPTION
Fixes an issue where billing only non-billable caused the user's EOD to be shortened.